### PR TITLE
qstruct/arraylist: Fixed wrong cast in qstruct_arraylist_create: struct arraylist casted to qstruct_result_t typedef

### DIFF
--- a/qstruct/arraylist.c
+++ b/qstruct/arraylist.c
@@ -15,7 +15,7 @@ qstruct_result_t qstruct_arraylist_create(qstruct_arraylist_t *arraylist, size_t
 	al->capacity = initialize_capacity;
 	al->array = malloc(initialize_capacity * value_size);
 	al->length = 0;
-	*arraylist = (qstruct_result_t) al;
+	*arraylist = (qstruct_arraylist_t) al;
 	return QSTRUCT_RESULT_OK;
 }
 


### PR DESCRIPTION
fix #84