### PR TITLE
qstruct/linkedlist: Fixed qstruct_linkedlist_remove doesnt free memory used by the entry

### DIFF
--- a/qstruct/linkedlist.c
+++ b/qstruct/linkedlist.c
@@ -118,6 +118,7 @@ qstruct_result_t qstruct_linkedlist_remove(qstruct_linkedlist_t list, size_t ind
 	} else {
 		next->previous = previous;
 	}
+	free(entry);
 	ll->length--;
 	return QSTRUCT_RESULT_OK;
 }


### PR DESCRIPTION
close #127