### PR TITLE
qstruct/rbtree: Fixed iterator fails when tree is empty

### DIFF
--- a/qstruct/hashmap.c
+++ b/qstruct/hashmap.c
@@ -77,12 +77,12 @@ static inline qstruct_result_t _hm_ensure_loadfactor(struct hashmap *hm) {
 			qstruct_rbtree_t *ob = obuckets[i];
 			if (ob != NULL) {
 				qstruct_run(qstruct_rbtree_iterator_create(ob, &it));
-				do {
+				while (qstruct_rbtree_iterator_next(it)) {
 					struct entry *e;
 					size_t e_size = qstruct_rbtree_iterator_current_size(it);
 					qstruct_run(qstruct_rbtree_iterator_current_valuep(it, (void **) &e));
 					qstruct_run(_hm_put(hm, e));
-				} while (qstruct_rbtree_iterator_next(it));
+				}
 				qstruct_run(qstruct_rbtree_destroy(ob));
 			}
 		}
@@ -144,11 +144,11 @@ qstruct_result_t qstruct_hashmap_destroy(qstruct_hashmap_t hashmap) {
 		if (bucket != NULL) {
 			qstruct_rbtree_iterator_t it;
 			qstruct_run(qstruct_rbtree_iterator_create(bucket, &it));
-			do {
+			while (qstruct_rbtree_iterator_next(it)) {
 				struct entry *e;
 				qstruct_run(qstruct_rbtree_iterator_current_valuep(it, (void **) &e));
 				free(e->value);
-			} while (qstruct_rbtree_iterator_next(it));
+			}
 			qstruct_run(qstruct_rbtree_iterator_destroy(it));
 			qstruct_run(qstruct_rbtree_destroy(bucket));
 		}

--- a/qstruct/rbtree.c
+++ b/qstruct/rbtree.c
@@ -444,7 +444,7 @@ qstruct_result_t qstruct_rbtree_iterator_create(qstruct_rbtree_t tree, qstruct_r
 	struct iterator *it = malloc(sizeof(struct iterator) + sizeof(struct node*) * t->length);
 	it->tree = t;
 	it->size = 0;
-	it->index = 0;
+	it->index = -1;
 	_rbt_iter_add_node(it, t->root);
 	*iterator = it;
 	return QSTRUCT_RESULT_OK;

--- a/qstruct/rbtree.h
+++ b/qstruct/rbtree.h
@@ -85,6 +85,7 @@ size_t qstruct_rbtree_length(qstruct_rbtree_t tree);
 qstruct_result_t qstruct_rbtree_iterator_create(qstruct_rbtree_t tree, qstruct_rbtree_iterator_t *iterator);
 
 /*
+ * NOTICE: you have to run next on first time
  * If has next goes to next item and return true
  * else return false
  * Time complexity: O(1)

--- a/test/qstruct/rbtree.c
+++ b/test/qstruct/rbtree.c
@@ -84,12 +84,12 @@ bool test_qstruct_rbtree_iterator() {
 	}
 	success &= qstruct_rbtree_iterator_create(tree, &it) == QSTRUCT_RESULT_OK;
 
-	do {
+	while (qstruct_rbtree_iterator_next(it)) {
 		success &= qstruct_rbtree_iterator_current_value(it, &res_value) == QSTRUCT_RESULT_OK;
 		bool found = 0;
 		for (int i = 0; i < array_len(values) && !found; i++) if (values[i] == res_value) found = true;
 		success &= found;
-	} while (qstruct_rbtree_iterator_next(it));
+	}
 
 	success &= qstruct_rbtree_iterator_destroy(it) == QSTRUCT_RESULT_OK;
 	success &= qstruct_rbtree_destroy(tree) == QSTRUCT_RESULT_OK;


### PR DESCRIPTION
close #199