### PR TITLE
qbuild: Fixed macro names in headers

### DIFF
--- a/qbuild/qbuild.h
+++ b/qbuild/qbuild.h
@@ -1,5 +1,5 @@
-#ifndef _qson_qson_h_
-#define _qson_qson_h_
+#ifndef _qbuild_qbuild_h_
+#define _qbuild_qbuild_h_
 
 #ifdef __cplusplus
 extern "C" {

--- a/qbuild/qbuild.internal.h
+++ b/qbuild/qbuild.internal.h
@@ -1,5 +1,5 @@
-#ifndef _qson_qson_internal_h_
-#define _qson_qson_internal_h_
+#ifndef _qbuild_qbuild_internal_h_
+#define _qbuild_qbuild_internal_h_
 
 #include <qbuild/qbuild.h>
 


### PR DESCRIPTION
close #238