### PR TITLE
qbuild: Moved included internal headers at end of internal header qbuild (after definition of macros and functions)

### DIFF
--- a/qbuild/qbuild.internal.h
+++ b/qbuild/qbuild.internal.h
@@ -5,8 +5,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <qbuild/qbuild.h>
-#include <qbuild/qson.internal.h>
-#include <qbuild/file/file.internal.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +18,9 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include <qbuild/qson.internal.h>
+#include <qbuild/file/file.internal.h>
 
 #endif
 


### PR DESCRIPTION
close #257