### PR TITLE
doc/qbuild/project: Changed suffix of file holding project info from json to jsonc, so comments are allowed

### DIFF
--- a/doc/qbuild/project.md
+++ b/doc/qbuild/project.md
@@ -12,7 +12,7 @@ Information about the project
 |---------|------------------------------------------------------|------------------|
 | name    | lower-case and `-` sepperted                         | `qbuild-example` |
 | version | dot sepperatted numbers, may have suffix like `beta` | `1.0.0-beta`     |
-> These info should be stored at file `project.json` at project dir.
+> These info should be stored at file `project.jsonc` at project dir.
 
 ## Implementation
 not implemented yet


### PR DESCRIPTION
close #265 