### PR TITLE
qbuild: Initialized package context with a normal and internal header and a source

### DIFF
--- a/qbuild/context/context.c
+++ b/qbuild/context/context.c
@@ -1,0 +1,2 @@
+#include "context.internal.h"
+

--- a/qbuild/context/context.h
+++ b/qbuild/context/context.h
@@ -1,0 +1,13 @@
+#ifndef _qbuild_context_context_h_
+#define _qbuild_context_context_h_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/qbuild/context/context.internal.h
+++ b/qbuild/context/context.internal.h
@@ -1,0 +1,16 @@
+#ifndef _qbuild_context_context_internal_h_
+#define _qbuild_context_context_internal_h_
+
+#include <qbuild/qbuild.internal.h>
+#include <qbuild/context/context.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+


### PR DESCRIPTION
close #297 