### PR TITLE
qbuild: Included header context in header qbuild

### DIFF
--- a/qbuild/qbuild.h
+++ b/qbuild/qbuild.h
@@ -19,6 +19,7 @@ typedef enum {
 #endif
 
 #include <qbuild/project/project.h>
+#include <qbuild/context/context.h>
 
 #endif
 


### PR DESCRIPTION
fix #304