### PR TITLE
qbuild/platform: Removed flexible array from internal struct qbuild_platform

### DIFF
--- a/qbuild/platform/platform.internal.h
+++ b/qbuild/platform/platform.internal.h
@@ -11,7 +11,7 @@ extern "C" {
 struct qbuild_platform {
 	char *name;
 	size_t parents_length;
-	struct qbuild_platform *parents[];
+	struct qbuild_platform **parents;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
close #339