### PR TITLE
qbuild: Included internal header context/context in internal header qbuild as last include so it can use structs from other internal headers

### DIFF
--- a/qbuild/qbuild.internal.h
+++ b/qbuild/qbuild.internal.h
@@ -24,9 +24,9 @@ extern "C" {
 #include <qbuild/qstruct.internal.h>
 #include <qbuild/file/file.internal.h>
 #include <qbuild/string/string.internal.h>
-#include <qbuild/context/context.internal.h>
 #include <qbuild/platform/platform.internal.h>
 #include <qbuild/project/project.internal.h>
+#include <qbuild/context/context.internal.h>
 
 #endif
 


### PR DESCRIPTION
close #342